### PR TITLE
Fix test for opening restaurant outside operating hours

### DIFF
--- a/backend/src/test/java/br/com/delivery/domain/restaurant/RestaurantTest.java
+++ b/backend/src/test/java/br/com/delivery/domain/restaurant/RestaurantTest.java
@@ -129,7 +129,10 @@ public class RestaurantTest {
   void shouldThrowWhenOpenAOpenedRestaurant() {
     Restaurant restaurant = Restaurant.create(ownerId, "restaurant", hours, address);
     restaurant.addMenuItem("item", "description", MenuItemCategory.DESSERT, money);
-    restaurant.openRestaurant(LocalTime.now());
+
+    LocalTime fakeTime = LocalTime.of(10, 10);
+    restaurant.openRestaurant(fakeTime);
+
     assertThrows(InvalidRestaurantException.class,
         () -> restaurant.openRestaurant(LocalTime.now()));
   }


### PR DESCRIPTION
This pull request updates the test for opening a restaurant to use a fixed time instead of the current time. This change ensures the test is more predictable and not dependent on the actual time when the test is run.

- **Test reliability improvement:**
  * In `RestaurantTest.java`, the `shouldThrowWhenOpenAOpenedRestaurant` test now uses a fixed `LocalTime` (`10:10`) when opening the restaurant, making the test deterministic and avoiding issues caused by timing differences.